### PR TITLE
Update SendGridEmail's content field to reflect the API

### DIFF
--- a/Sources/SendGridKit/Models/EmailContent.swift
+++ b/Sources/SendGridKit/Models/EmailContent.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct EmailContent: Encodable {
+    public let type: String
+    public let value: String
+
+    public init(type: String, value: String) {
+        self.type = type
+        self.value = value
+    }
+}
+
+extension EmailContent: ExpressibleByStringLiteral {
+    public init(stringLiteral value: StringLiteralType) {
+        self.init(type: "text/plain", value: value)
+    }
+}

--- a/Sources/SendGridKit/Models/SendGridEmail.swift
+++ b/Sources/SendGridKit/Models/SendGridEmail.swift
@@ -13,7 +13,7 @@ public struct SendGridEmail: Encodable {
     public var subject: String?
     
     /// An array in which you may specify the content of your email.
-    public var content: [[String: String]]
+    public var content: [EmailContent]
 
     /// An array of objects in which you can specify any attachments you want to include.
     public var attachments: [EmailAttachment]?
@@ -55,7 +55,7 @@ public struct SendGridEmail: Encodable {
                 from: EmailAddress? = nil,
                 replyTo: EmailAddress? = nil,
                 subject: String? = nil,
-                content: [[String: String]],
+                content: [EmailContent],
                 attachments: [EmailAttachment]? = nil,
                 templateId: String? = nil,
                 sections: [String: String]? = nil,


### PR DESCRIPTION
According to the docs the content field needs to look like this
```
{
  // ...

  "content": [
    {
      "type": "text/html",
      "value": "Email Content"
    }
  ]

  // ...
}
```

rather than how it is in the current implementation
```
{
  // ...

  "content": [
    { "text/html": "Email Content"}
  ],

  // ...
}

```