### PR TITLE
Optional content field

### DIFF
--- a/Sources/SendGridKit/Models/SendGridEmail.swift
+++ b/Sources/SendGridKit/Models/SendGridEmail.swift
@@ -13,7 +13,7 @@ public struct SendGridEmail: Encodable {
     public var subject: String?
     
     /// An array in which you may specify the content of your email.
-    public var content: [[String: String]]
+    public var content: [[String: String]]?
 
     /// An array of objects in which you can specify any attachments you want to include.
     public var attachments: [EmailAttachment]?
@@ -55,7 +55,7 @@ public struct SendGridEmail: Encodable {
                 from: EmailAddress? = nil,
                 replyTo: EmailAddress? = nil,
                 subject: String? = nil,
-                content: [[String: String]],
+                content: [[String: String]]? = nil,
                 attachments: [EmailAttachment]? = nil,
                 templateId: String? = nil,
                 sections: [String: String]? = nil,


### PR DESCRIPTION
I made the content field of `SendGridEmail` optional, because it is required for using dynamic templates as described in issue #2 .

Closes #2 