### PR TITLE
Linux Compatibility

### DIFF
--- a/Sources/SendGridKit/SendGridClient.swift
+++ b/Sources/SendGridKit/SendGridClient.swift
@@ -2,6 +2,7 @@ import Foundation
 import NIO
 import AsyncHTTPClient
 import NIOHTTP1
+import NIOFoundationCompat
 
 public struct SendGridClient {
     
@@ -45,9 +46,9 @@ public struct SendGridClient {
         guard response.status != .ok else { return }
         
         // JSONDecoder will handle empty body by throwing decoding error
-        let data = response.body?.getData(at: 0, length: response.body?.readableBytes ?? 0) ??  Data()
-        
-        throw try decoder.decode(SendGridError.self, from: data)
+        let byteBuffer = response.body ?? ByteBuffer(.init())
+                
+        throw try decoder.decode(SendGridError.self, from: byteBuffer)
         
     }
 }

--- a/Sources/SendGridKit/SendGridClient.swift
+++ b/Sources/SendGridKit/SendGridClient.swift
@@ -45,9 +45,9 @@ public struct SendGridClient {
         guard response.status != .ok else { return }
         
         // JSONDecoder will handle empty body by throwing decoding error
-        let byteBuffer = response.body ?? ByteBuffer(.init())
-                
-        throw try decoder.decode(SendGridError.self, from: byteBuffer)
+        let data = response.body?.getData(at: 0, length: response.body?.readableBytes ?? 0) ??  Data()
+        
+        throw try decoder.decode(SendGridError.self, from: data)
         
     }
 }


### PR DESCRIPTION
Amazonlinux2 (5.7) throws an error:

```
remark: Incremental compilation has been disabled: it is not compatible with whole module optimization[1394/1396] Compiling SendGridKit AdvancedSuppressionManager.swift
/__w/api/api/.build/checkouts/sendgrid-kit/Sources/SendGridKit/SendGridClient.swift:50:60: error: cannot convert value of type 'ByteBuffer' to expected argument type 'Data'
```

This PR fixes that by providing the `NIOFoundationCompat` module for Bytebuffer. It's needed for Linux.