### PR TITLE
Fix email send response handling

### DIFF
--- a/Sources/SendGridKit/SendGridClient.swift
+++ b/Sources/SendGridKit/SendGridClient.swift
@@ -43,7 +43,7 @@ public struct SendGridClient {
         ).get()
         
         // If the request was accepted, simply return
-        guard response.status != .ok else { return }
+        guard response.status != .ok && response.status != .accepted else { return }
         
         // JSONDecoder will handle empty body by throwing decoding error
         let byteBuffer = response.body ?? ByteBuffer(.init())


### PR DESCRIPTION
The `send(email:)` call always throws, even in the success case. This is because the API returns `202 accepted`, not `200 ok` in the success case.

This is why I've added a check against `.accepted`. To not break anything else, I've kept the check against `.ok`, but from my understanding it could be removed.